### PR TITLE
Include obsoleteTag to bundle generation

### DIFF
--- a/lib/multisig/multisig.js
+++ b/lib/multisig/multisig.js
@@ -101,6 +101,7 @@ Multisig.initiateTransfer = function(input, remainderAddress, transfers, callbac
     transfers.forEach(function(thisTransfer) {
         thisTransfer.message = thisTransfer.message ? thisTransfer.message : '';
         thisTransfer.tag = thisTransfer.tag ? thisTransfer.tag : '';
+        thisTransfer.obsoleteTag = thisTransfer.obsoleteTag ? thisTransfer.obsoleteTag : '';        
         thisTransfer.address = Utils.noChecksum(thisTransfer.address);
     })
 

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -457,6 +457,7 @@ var isBundle = function(bundle) {
 }
 
 module.exports = {
+    inputValidator      : inputValidator,    
     convertUnits        : convertUnits,
     addChecksum         : addChecksum,
     noChecksum          : noChecksum,
@@ -468,6 +469,5 @@ module.exports = {
     fromTrytes          : ascii.fromTrytes,
     extractJson         : extractJson,
     validateSignatures  : validateSignatures,
-    isBundle            : isBundle,
-    inputValidator      : inputValidator
+    isBundle            : isBundle
 }

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -457,6 +457,7 @@ var isBundle = function(bundle) {
 }
 
 module.exports = {
+    inputValidator      : inputValidator,    
     convertUnits        : convertUnits,
     addChecksum         : addChecksum,
     noChecksum          : noChecksum,
@@ -469,5 +470,4 @@ module.exports = {
     extractJson         : extractJson,
     validateSignatures  : validateSignatures,
     isBundle            : isBundle,
-    inputValidator      : inputValidator
 }


### PR DESCRIPTION
This caused the validation functions to throw.